### PR TITLE
fix ogp

### DIFF
--- a/content/txjp.md
+++ b/content/txjp.md
@@ -19,7 +19,6 @@ seo:
     - name: 'og:image'
       value: https://defigeek.xyz/images/DFGC_logo_banner02.png
       keyName: property
-      relativeUrl: true
     - name: 'twitter:card'
       value: summary
 layout: page

--- a/data/config.json
+++ b/data/config.json
@@ -30,7 +30,7 @@
             },
             {
                 "label": "EN",
-                "url": "",
+                "url": "#",
                 "has_icon": true,
                 "icon": "earth"
             }

--- a/v1-checklist.md
+++ b/v1-checklist.md
@@ -41,14 +41,14 @@
 
 ###  5. OGPチェック
 - [Twitter Card Validator](https://cards-dev.twitter.com/validator)と[OGP確認](https://rakko.tools/tools/9/)でチェック
-- [ ] landing
-- [ ] about
-- [ ] txjp
-- [ ] brand
-- [ ] join
-- [ ] blog
-- [ ] blog-post-official
-- [ ] blog-post-writer
+- [x] landing
+- [x] about
+- [x] txjp ※relativeURLを削除
+- [x] brand
+- [x] join
+- [x] blog
+- [x] blog-post-official
+- [x] blog-post-writer
 
 ### 6. インフラ準備
 - [x] defigeek.xyzリポジトリ作成


### PR DESCRIPTION
v1リリース後の動作チェックで以下の不具合を修正した。
- txjpページのOGPイメージが取得できない
- ヘッダーの /en リンクがリンク切れになりページから離れてしまう